### PR TITLE
Fix typo

### DIFF
--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -89,7 +89,7 @@ For information about what each errand does and guidance for activating or deact
   </tr>
   <tr>
     <td>Run BOSH Configurator</td>
-    <td>Uploads the stemcells required for the BOSH release so that a9s BOSH for PCF can provision Elasticsearch instances. 
+    <td>Uploads the releases required to the a9s BOSH Director so that a9s BOSH for PCF can provision Elasticsearch instances.
         Deactivating this errand may speed up the deployment of tiles.
       <p class="note"><strong>Note</strong>: Pivotal recommends leaving this errand selected to keep the tile configuration up-to-date.</p>
     </td>

--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -148,7 +148,7 @@ Follow the instructions below to unbind your service instance from all apps and 
 1. List available services by entering the following command:
 
     ```
-    $ cf service
+    $ cf services
     ```
 
     For example, the following shows that `my-elasticsearch-service` is bound to the `a9s-elasticsearch-app` app.


### PR DESCRIPTION
This PR fixes a typo where the command "cf services" is actually run even though the text stipulates "cf service".

It also changes the explanation in the BOSH errand paragraph, since the stemcells have been removed from the tiles – but the task still uploads the releases on which it depends.